### PR TITLE
Add PresavePopup component and update color scheme

### DIFF
--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -59,7 +59,15 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
 
   const PopupContent = () => (
     <DialogContent className="max-w-sm mx-auto bg-black/90 border border-white/20 backdrop-blur-sm rounded-lg">
-      <DialogHeader className="text-center space-y-6">
+      <DialogHeader className="text-center space-y-4">
+        <div className="mx-auto w-32 h-32 rounded-lg overflow-hidden">
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2F0dd1a1ded0234fbb9d750f1dcd8d1bea%2F11e1ab4378c44b54a7e4881fd22d97bc?format=webp&width=800"
+            alt="Be Like You - Track Cover"
+            className="w-full h-full object-cover"
+          />
+        </div>
+
         <DialogTitle className="text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase">
           "Be Like You"
         </DialogTitle>

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -73,7 +73,7 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
         </DialogTitle>
 
         <DialogDescription className="text-white/80 text-sm font-['Montserrat'] text-center">
-          New track from HIDDNHILLS
+          New track from HIDDNHILLS August 8, 2025
         </DialogDescription>
       </DialogHeader>
 

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -58,21 +58,22 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   };
 
   const PopupContent = () => (
-    <DialogContent className="max-w-sm mx-auto bg-black/90 border border-white/20 backdrop-blur-sm rounded-lg">
+    <DialogContent className="max-w-sm mx-4 sm:mx-auto bg-black/90 border border-white/20 backdrop-blur-sm rounded-lg p-4 sm:p-6 max-h-[90vh] overflow-y-auto">
       <DialogHeader className="text-center space-y-4">
-        <div className="mx-auto w-32 h-32 rounded-lg overflow-hidden">
+        <div className="mx-auto w-24 h-24 sm:w-32 sm:h-32 rounded-lg overflow-hidden">
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F0dd1a1ded0234fbb9d750f1dcd8d1bea%2F11e1ab4378c44b54a7e4881fd22d97bc?format=webp&width=800"
             alt="Be Like You - Track Cover"
             className="w-full h-full object-cover"
+            loading="lazy"
           />
         </div>
 
-        <DialogTitle className="text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase text-center">
+        <DialogTitle className="text-lg sm:text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase text-center">
           "Be Like You"
         </DialogTitle>
 
-        <DialogDescription className="text-white/80 text-sm font-['Montserrat'] text-center">
+        <DialogDescription className="text-white/80 text-sm font-['Montserrat'] text-center px-2">
           New track from HIDDNHILLS August 8, 2025
         </DialogDescription>
       </DialogHeader>
@@ -80,7 +81,9 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
       <div className="space-y-3 mt-6">
         <Button
           onClick={handlePresaveClick}
-          className="w-full bg-white/20 text-white font-['Montserrat'] font-medium py-3 px-6 rounded-md hover:bg-white/30 transition-colors duration-300 uppercase text-sm tracking-wide"
+          className="w-full bg-white/20 text-white font-['Montserrat'] font-medium py-3 px-6 rounded-md hover:bg-white/30 active:bg-white/40 transition-colors duration-300 uppercase text-sm tracking-wide min-h-[48px] touch-manipulation"
+          type="button"
+          aria-label="Presave Be Like You on music platforms"
         >
           Presave New Music
         </Button>
@@ -88,7 +91,9 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
         <DialogClose asChild>
           <Button
             variant="ghost"
-            className="w-full text-white/60 hover:text-white hover:bg-white/10 transition-colors font-['Montserrat'] text-sm"
+            className="w-full text-white/60 hover:text-white hover:bg-white/10 active:bg-white/20 transition-colors font-['Montserrat'] text-sm min-h-[48px] touch-manipulation"
+            type="button"
+            aria-label="Close popup"
           >
             Later
           </Button>

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -29,11 +29,21 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   const [open, setOpen] = useState(false);
   const [hasShown, setHasShown] = useState(false);
 
+  // Check localStorage on mount to prevent repeated auto-shows
+  useEffect(() => {
+    const hasSeenPopup = localStorage.getItem("presave-popup-shown");
+    if (hasSeenPopup) {
+      setHasShown(true);
+    }
+  }, []);
+
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
     onOpenChange?.(newOpen);
     if (newOpen) {
       setHasShown(true);
+      // Remember that user has seen the popup
+      localStorage.setItem("presave-popup-shown", "true");
     }
   };
 
@@ -43,6 +53,7 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
         if (!hasShown) {
           setOpen(true);
           setHasShown(true);
+          localStorage.setItem("presave-popup-shown", "true");
         }
       }, delay);
 

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -58,48 +58,33 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   };
 
   const PopupContent = () => (
-    <DialogContent className="max-w-md mx-auto bg-artistic-charcoal border-2 border-artistic-silver/20 shadow-luxury backdrop-blur-sm">
-      <DialogHeader className="text-center space-y-4">
-        <div className="mx-auto w-16 h-16 bg-gradient-to-br from-artistic-pearl to-artistic-silver rounded-full flex items-center justify-center mb-2">
-          <Music className="w-8 h-8 text-artistic-charcoal" />
-        </div>
-
-        <DialogTitle className="text-2xl font-black tracking-wide bg-gradient-to-br from-white via-artistic-pearl to-artistic-silver bg-clip-text text-transparent leading-none uppercase font-['Montserrat']">
-          New Music Alert
+    <DialogContent className="max-w-sm mx-auto bg-black/90 border border-white/20 backdrop-blur-sm rounded-lg">
+      <DialogHeader className="text-center space-y-6">
+        <DialogTitle className="text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase">
+          "Be Like You"
         </DialogTitle>
 
-        <DialogDescription className="text-artistic-pearl/80 text-sm leading-relaxed space-y-2">
-          <div className="text-lg font-semibold text-white mb-2">
-            "Be Like You"
-          </div>
-          <div>
-            Get ready for the latest track from HIDDNHILLS. Presave now to be
-            the first to experience it when it drops.
-          </div>
+        <DialogDescription className="text-white/80 text-sm font-['Montserrat']">
+          New track from HIDDNHILLS
         </DialogDescription>
       </DialogHeader>
 
-      <div className="space-y-4 mt-6">
+      <div className="space-y-3 mt-6">
         <Button
           onClick={handlePresaveClick}
-          className="w-full bg-gradient-to-r from-artistic-pearl to-artistic-silver text-artistic-charcoal font-bold py-3 px-6 rounded-lg hover:from-white hover:to-artistic-pearl transition-all duration-300 transform hover:scale-105 shadow-lg"
+          className="w-full bg-white/20 text-white font-['Montserrat'] font-medium py-3 px-6 rounded-md hover:bg-white/30 transition-colors duration-300 uppercase text-sm tracking-wide"
         >
-          <ExternalLink className="w-4 h-4 mr-2" />
-          Presave "Be Like You"
+          Presave Now
         </Button>
 
         <DialogClose asChild>
           <Button
             variant="ghost"
-            className="w-full text-artistic-silver/60 hover:text-artistic-pearl hover:bg-artistic-smoke/20 transition-colors"
+            className="w-full text-white/60 hover:text-white hover:bg-white/10 transition-colors font-['Montserrat'] text-sm"
           >
-            Maybe Later
+            Later
           </Button>
         </DialogClose>
-      </div>
-
-      <div className="text-center text-xs text-artistic-silver/40 mt-4">
-        Underground Hip-Hop • Las Vegas
       </div>
     </DialogContent>
   );

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -68,11 +68,11 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
           />
         </div>
 
-        <DialogTitle className="text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase">
+        <DialogTitle className="text-xl font-medium tracking-wide text-white font-['Montserrat'] uppercase text-center">
           "Be Like You"
         </DialogTitle>
 
-        <DialogDescription className="text-white/80 text-sm font-['Montserrat']">
+        <DialogDescription className="text-white/80 text-sm font-['Montserrat'] text-center">
           New track from HIDDNHILLS
         </DialogDescription>
       </DialogHeader>
@@ -82,7 +82,7 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
           onClick={handlePresaveClick}
           className="w-full bg-white/20 text-white font-['Montserrat'] font-medium py-3 px-6 rounded-md hover:bg-white/30 transition-colors duration-300 uppercase text-sm tracking-wide"
         >
-          Presave Now
+          Presave New Music
         </Button>
 
         <DialogClose asChild>

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -9,7 +9,7 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Music, X } from "lucide-react";
+import { Music } from "lucide-react";
 
 interface PresavePopupProps {
   isOpen?: boolean;

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ExternalLink, Music, X } from "lucide-react";
+
+interface PresavePopupProps {
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  autoShow?: boolean;
+  delay?: number;
+}
+
+export const PresavePopup: React.FC<PresavePopupProps> = ({
+  isOpen,
+  onOpenChange,
+  trigger,
+  autoShow = false,
+  delay = 3000,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [hasShown, setHasShown] = useState(false);
+
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen);
+    onOpenChange?.(newOpen);
+    if (newOpen) {
+      setHasShown(true);
+    }
+  };
+
+  useEffect(() => {
+    if (autoShow && !hasShown) {
+      const timer = setTimeout(() => {
+        if (!hasShown) {
+          setOpen(true);
+          setHasShown(true);
+        }
+      }, delay);
+
+      return () => clearTimeout(timer);
+    }
+  }, [autoShow, delay, hasShown]);
+
+  const presaveUrl = "https://distrokid.com/hyperfollow/hiddnhills/be-like-you";
+
+  const handlePresaveClick = () => {
+    window.open(presaveUrl, "_blank", "noopener,noreferrer");
+    handleOpenChange(false);
+  };
+
+  const PopupContent = () => (
+    <DialogContent className="max-w-md mx-auto bg-artistic-charcoal border-2 border-artistic-silver/20 shadow-luxury backdrop-blur-sm">
+      <DialogHeader className="text-center space-y-4">
+        <div className="mx-auto w-16 h-16 bg-gradient-to-br from-artistic-pearl to-artistic-silver rounded-full flex items-center justify-center mb-2">
+          <Music className="w-8 h-8 text-artistic-charcoal" />
+        </div>
+
+        <DialogTitle className="text-2xl font-black tracking-wide bg-gradient-to-br from-white via-artistic-pearl to-artistic-silver bg-clip-text text-transparent leading-none uppercase font-['Montserrat']">
+          New Music Alert
+        </DialogTitle>
+
+        <DialogDescription className="text-artistic-pearl/80 text-sm leading-relaxed space-y-2">
+          <div className="text-lg font-semibold text-white mb-2">
+            "Be Like You"
+          </div>
+          <div>
+            Get ready for the latest track from HIDDNHILLS. Presave now to be
+            the first to experience it when it drops.
+          </div>
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 mt-6">
+        <Button
+          onClick={handlePresaveClick}
+          className="w-full bg-gradient-to-r from-artistic-pearl to-artistic-silver text-artistic-charcoal font-bold py-3 px-6 rounded-lg hover:from-white hover:to-artistic-pearl transition-all duration-300 transform hover:scale-105 shadow-lg"
+        >
+          <ExternalLink className="w-4 h-4 mr-2" />
+          Presave "Be Like You"
+        </Button>
+
+        <DialogClose asChild>
+          <Button
+            variant="ghost"
+            className="w-full text-artistic-silver/60 hover:text-artistic-pearl hover:bg-artistic-smoke/20 transition-colors"
+          >
+            Maybe Later
+          </Button>
+        </DialogClose>
+      </div>
+
+      <div className="text-center text-xs text-artistic-silver/40 mt-4">
+        Underground Hip-Hop • Las Vegas
+      </div>
+    </DialogContent>
+  );
+
+  if (trigger) {
+    return (
+      <Dialog
+        open={isOpen ?? open}
+        onOpenChange={onOpenChange ?? handleOpenChange}
+      >
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <PopupContent />
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog
+      open={isOpen ?? open}
+      onOpenChange={onOpenChange ?? handleOpenChange}
+    >
+      <PopupContent />
+    </Dialog>
+  );
+};
+
+export default PresavePopup;

--- a/src/index.css
+++ b/src/index.css
@@ -256,21 +256,21 @@ a:focus-visible {
 
 @layer components {
   .elegant-text {
-    @apply text-gold-pure;
+    @apply text-white;
     text-shadow: 0 0 10px currentColor;
   }
 
-  .gold-shimmer {
-    @apply animate-gold-shimmer;
+  .silver-shimmer {
+    @apply animate-subtle-shimmer;
     text-shadow:
-      0 0 5px #ffd700,
-      0 0 10px #ffd700,
-      0 0 15px #ffd700,
-      0 0 20px #ffd700;
+      0 0 5px #c0c0c0,
+      0 0 10px #c0c0c0,
+      0 0 15px #c0c0c0,
+      0 0 20px #c0c0c0;
   }
 
   .basquiat-text {
-    @apply font-graffiti text-gold-pure;
+    @apply font-graffiti text-white;
     text-shadow:
       2px 2px 0px #000000,
       4px 4px 0px #bf754b,
@@ -321,7 +321,7 @@ a:focus-visible {
 
   /* Elegant pop art color variations */
   .pop-variant-1 {
-    background: linear-gradient(45deg, #ffd700, #d4af37);
+    background: linear-gradient(45deg, #c0c0c0, #e5e4e2);
     color: #000000;
   }
 
@@ -337,7 +337,7 @@ a:focus-visible {
 
   .pop-variant-4 {
     background: linear-gradient(45deg, #734434, #732f17);
-    color: #ffd700;
+    color: #c0c0c0;
   }
 
   /* Luxury screen printing effect */
@@ -373,14 +373,14 @@ a:focus-visible {
 
   /* Luxury container styling */
   .luxury-container {
-    border: 3px solid #ffd700;
+    border: 3px solid #c0c0c0;
     border-radius: 8px;
     background: linear-gradient(
       to bottom,
       #ffffff 0%,
       #ffffff 30%,
-      #ffd700 30%,
-      #ffd700 70%,
+      #c0c0c0 30%,
+      #c0c0c0 70%,
       #000000 70%,
       #000000 100%
     );
@@ -398,13 +398,13 @@ a:focus-visible {
     left: 10%;
     right: 10%;
     height: 30%;
-    background: #ffd700;
+    background: #c0c0c0;
     border-radius: 50%;
   }
 
   /* Elegant color variations inspired by luxury fashion */
   .elegant-1 {
-    background: linear-gradient(45deg, #ffd700, #d9b6a3);
+    background: linear-gradient(45deg, #c0c0c0, #d9b6a3);
     color: #000;
   }
 
@@ -420,7 +420,7 @@ a:focus-visible {
 
   .elegant-4 {
     background: linear-gradient(45deg, #734434, #732f17);
-    color: #ffd700;
+    color: #c0c0c0;
   }
 
   /* Enhanced Basquiat-style elements with new palette */
@@ -486,7 +486,7 @@ a:focus-visible {
     top: -20px;
     right: -15px;
     font-size: 16px;
-    color: #ffd700;
+    color: #c0c0c0;
     transform: rotate(15deg);
     z-index: 1;
   }
@@ -565,14 +565,14 @@ a:focus-visible {
       135deg,
       #000000 0%,
       #404040 25%,
-      #ffd700 50%,
+      #c0c0c0 50%,
       #bf754b 75%,
       #000000 100%
     );
   }
 
   .gold-gradient {
-    background: linear-gradient(45deg, #ffd700, #d4af37, #b8860b);
+    background: linear-gradient(45deg, #c0c0c0, #e5e4e2, #d3d3d3);
   }
 
   .velvet-gradient {
@@ -583,11 +583,11 @@ a:focus-visible {
   .luxury-gradient-1 {
     background: linear-gradient(
       45deg,
-      #ffd700 0%,
+      #c0c0c0 0%,
       #bf754b 25%,
       #a6583c 50%,
       #d9b6a3 75%,
-      #ffd700 100%
+      #c0c0c0 100%
     );
   }
 
@@ -596,7 +596,7 @@ a:focus-visible {
       135deg,
       #000000 0%,
       #734434 25%,
-      #ffd700 50%,
+      #c0c0c0 50%,
       #d2d9d8 75%,
       #000000 100%
     );
@@ -606,7 +606,7 @@ a:focus-visible {
     border: 1px solid transparent;
     background:
       linear-gradient(#000000, #000000) padding-box,
-      linear-gradient(45deg, #ffd700, #bf754b) border-box;
+      linear-gradient(45deg, #c0c0c0, #bf754b) border-box;
   }
 
   /* Luxury borders */
@@ -614,7 +614,7 @@ a:focus-visible {
     border: 3px solid transparent;
     background:
       linear-gradient(#000000, #000000) padding-box,
-      linear-gradient(45deg, #ffd700, #d9b6a3, #bf754b, #a6583c) border-box;
+      linear-gradient(45deg, #c0c0c0, #d9b6a3, #bf754b, #a6583c) border-box;
   }
 
   /* Enhanced Basquiat-style rough border with new colors */
@@ -622,7 +622,7 @@ a:focus-visible {
     border: 3px solid transparent;
     background:
       linear-gradient(#000000, #000000) padding-box,
-      linear-gradient(45deg, #ffd700, #bf754b, #a6583c) border-box;
+      linear-gradient(45deg, #c0c0c0, #bf754b, #a6583c) border-box;
     filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='roughpaper'%3E%3CfeTurbulence baseFrequency='0.04' numOctaves='5' result='noise' seed='1'/%3E%3CfeDisplacementMap in='SourceGraphic' in2='noise' scale='2'/%3E%3C/filter%3E%3C/svg%3E#roughpaper");
   }
 
@@ -687,7 +687,7 @@ a:focus-visible {
     left: 0;
     width: 100%;
     height: 2px;
-    background: linear-gradient(90deg, transparent, #ffd700, transparent);
+    background: linear-gradient(90deg, transparent, #c0c0c0, transparent);
     animation: scan-line 2s linear infinite;
   }
 
@@ -815,7 +815,7 @@ a:focus-visible {
 
   /* Elegant text effects */
   .elegant-text-1 {
-    background: linear-gradient(45deg, #ffd700, #d4af37);
+    background: linear-gradient(45deg, #c0c0c0, #e5e4e2);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -868,10 +868,10 @@ a:focus-visible {
   /* Elegant glow effects */
   .gold-glow {
     box-shadow:
-      0 0 5px #ffd700,
-      0 0 10px #ffd700,
-      0 0 15px #ffd700,
-      0 0 20px #ffd700;
+      0 0 5px #c0c0c0,
+      0 0 10px #c0c0c0,
+      0 0 15px #c0c0c0,
+      0 0 20px #c0c0c0;
   }
 
   .velvet-glow {
@@ -944,7 +944,7 @@ a:focus-visible {
 
   /* Color utilities */
   .text-gold {
-    color: #ffd700;
+    color: #c0c0c0;
   }
 
   .text-velvet {
@@ -972,8 +972,8 @@ a:focus-visible {
     background: linear-gradient(
       45deg,
       transparent 30%,
-      #ffd700 30%,
-      #ffd700 70%,
+      #c0c0c0 30%,
+      #c0c0c0 70%,
       transparent 70%
     );
     transform: rotate(-2deg);
@@ -1014,7 +1014,7 @@ a:focus-visible {
 
   /* Luxury block backgrounds */
   .luxury-block-1 {
-    background: linear-gradient(135deg, #ffd700 0%, #d4af37 100%);
+    background: linear-gradient(135deg, #c0c0c0 0%, #e5e4e2 100%);
   }
 
   .luxury-block-2 {

--- a/src/index.css
+++ b/src/index.css
@@ -968,7 +968,7 @@ a:focus-visible {
   }
 
   /* Paint brush stroke effects with new colors */
-  .brush-stroke-gold {
+  .brush-stroke-silver {
     background: linear-gradient(
       45deg,
       transparent 30%,

--- a/src/index.css
+++ b/src/index.css
@@ -114,7 +114,7 @@ a:focus-visible {
     --popover: 0 0% 5%;
     --popover-foreground: 0 0% 95%;
 
-    --primary: 51 100% 50%;
+    --primary: 0 0% 75%;
     --primary-foreground: 0 0% 5%;
 
     --secondary: 28 32% 25%;
@@ -123,7 +123,7 @@ a:focus-visible {
     --muted: 0 0% 15%;
     --muted-foreground: 0 0% 65%;
 
-    --accent: 51 100% 50%;
+    --accent: 0 0% 75%;
     --accent-foreground: 0 0% 5%;
 
     --destructive: 0 62% 30%;
@@ -131,7 +131,7 @@ a:focus-visible {
 
     --border: 0 0% 20%;
     --input: 0 0% 20%;
-    --ring: 51 100% 50%;
+    --ring: 0 0% 75%;
     --sidebar-background: 0 0% 8%;
     --sidebar-foreground: 0 0% 75%;
     --sidebar-primary: 51 100% 50%;

--- a/src/index.css
+++ b/src/index.css
@@ -943,7 +943,7 @@ a:focus-visible {
   }
 
   /* Color utilities */
-  .text-gold {
+  .text-silver {
     color: #c0c0c0;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -866,7 +866,7 @@ a:focus-visible {
   }
 
   /* Elegant glow effects */
-  .gold-glow {
+  .silver-glow {
     box-shadow:
       0 0 5px #c0c0c0,
       0 0 10px #c0c0c0,

--- a/src/index.css
+++ b/src/index.css
@@ -134,12 +134,12 @@ a:focus-visible {
     --ring: 0 0% 75%;
     --sidebar-background: 0 0% 8%;
     --sidebar-foreground: 0 0% 75%;
-    --sidebar-primary: 51 100% 50%;
+    --sidebar-primary: 0 0% 75%;
     --sidebar-primary-foreground: 0 0% 5%;
     --sidebar-accent: 0 0% 15%;
     --sidebar-accent-foreground: 0 0% 75%;
     --sidebar-border: 0 0% 20%;
-    --sidebar-ring: 51 100% 50%;
+    --sidebar-ring: 0 0% 75%;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -571,7 +571,7 @@ a:focus-visible {
     );
   }
 
-  .gold-gradient {
+  .silver-gradient {
     background: linear-gradient(45deg, #c0c0c0, #e5e4e2, #d3d3d3);
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -96,12 +96,12 @@ a:focus-visible {
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 0 0% 25%;
-    --sidebar-primary: 51 100% 50%;
+    --sidebar-primary: 0 0% 75%;
     --sidebar-primary-foreground: 0 0% 5%;
     --sidebar-accent: 0 0% 96%;
     --sidebar-accent-foreground: 0 0% 25%;
     --sidebar-border: 0 0% 90%;
-    --sidebar-ring: 51 100% 50%;
+    --sidebar-ring: 0 0% 75%;
   }
 
   .dark {

--- a/src/index.css
+++ b/src/index.css
@@ -73,7 +73,7 @@ a:focus-visible {
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 5%;
 
-    --primary: 51 100% 50%;
+    --primary: 0 0% 75%;
     --primary-foreground: 0 0% 5%;
 
     --secondary: 28 32% 63%;
@@ -82,7 +82,7 @@ a:focus-visible {
     --muted: 0 0% 96%;
     --muted-foreground: 0 0% 45%;
 
-    --accent: 51 100% 50%;
+    --accent: 0 0% 75%;
     --accent-foreground: 0 0% 5%;
 
     --destructive: 0 84% 60%;
@@ -90,7 +90,7 @@ a:focus-visible {
 
     --border: 0 0% 90%;
     --input: 0 0% 90%;
-    --ring: 51 100% 50%;
+    --ring: 0 0% 75%;
 
     --radius: 0.5rem;
 

--- a/src/index.css
+++ b/src/index.css
@@ -60,7 +60,7 @@ a:focus-visible {
 
 @layer base {
   /**
-   * Sophisticated Black, White, Gold & Velvet CSS Variables
+   * Sophisticated Black, White & Silver CSS Variables
    * Elegant, high-contrast palette with luxurious accents
   */
   :root {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -108,8 +108,13 @@ const Index = () => {
         </div>
       </div>
 
-      {/* Presave Popup - Auto-shows after 5 seconds */}
-      <PresavePopup autoShow={true} delay={5000} />
+      {/* Presave Popup - Auto-shows after 5 seconds and manual trigger */}
+      <PresavePopup
+        autoShow={true}
+        delay={5000}
+        isOpen={presavePopupOpen}
+        onOpenChange={setPresavePopupOpen}
+      />
     </PageLayout>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -84,6 +84,18 @@ const Index = () => {
               <LoopingNavigationButtons
                 slotMachineOptions={slotMachineOptions}
               />
+
+              {/* Presave Button */}
+              <div className="mt-6 pt-4 border-t border-artistic-silver/10">
+                <Button
+                  onClick={() => setPresavePopupOpen(true)}
+                  className="w-full bg-gradient-to-r from-artistic-pearl/20 to-artistic-silver/20 border border-artistic-silver/30 text-artistic-pearl hover:from-artistic-pearl/30 hover:to-artistic-silver/30 hover:text-white transition-all duration-300 backdrop-blur-sm"
+                  size="sm"
+                >
+                  <Music className="w-4 h-4 mr-2" />
+                  New Music: "Be Like You"
+                </Button>
+              </div>
             </div>
           </div>
         </section>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -93,7 +93,7 @@ const Index = () => {
                   size="sm"
                 >
                   <Music className="w-4 h-4 mr-2" />
-                  New Music
+                  Presave New Music
                 </Button>
               </div>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { PageLayout } from "@/components/PageLayout";
 import { LoopingNavigationButtons } from "@/components/LoopingNavigationButtons";
 import { PresavePopup } from "@/components/PresavePopup";
+import { Button } from "@/components/ui/button";
+import { Music } from "lucide-react";
 
 // Slot machine alternatives for each button
 const slotMachineOptions = {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -51,6 +51,8 @@ const rightMarqueeItems = [
 ];
 
 const Index = () => {
+  const [presavePopupOpen, setPresavePopupOpen] = useState(false);
+
   return (
     <PageLayout
       leftMarqueeItems={leftMarqueeItems}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -83,6 +83,9 @@ const Index = () => {
           </div>
         </div>
       </div>
+
+      {/* Presave Popup - Auto-shows after 5 seconds */}
+      <PresavePopup autoShow={true} delay={5000} />
     </PageLayout>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -89,8 +89,10 @@ const Index = () => {
               <div className="mt-6 pt-4 border-t border-white/10">
                 <Button
                   onClick={() => setPresavePopupOpen(true)}
-                  className="w-full bg-white/20 text-white font-['Montserrat'] font-medium hover:bg-white/30 transition-colors duration-300 uppercase text-sm tracking-wide rounded-md"
+                  className="w-full bg-white/20 text-white font-['Montserrat'] font-medium hover:bg-white/30 active:bg-white/40 transition-colors duration-300 uppercase text-sm tracking-wide rounded-md min-h-[48px] touch-manipulation"
                   size="sm"
+                  type="button"
+                  aria-label="Open presave popup for new music"
                 >
                   <Music className="w-4 h-4 mr-2" />
                   Presave New Music

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -86,14 +86,14 @@ const Index = () => {
               />
 
               {/* Presave Button */}
-              <div className="mt-6 pt-4 border-t border-artistic-silver/10">
+              <div className="mt-6 pt-4 border-t border-white/10">
                 <Button
                   onClick={() => setPresavePopupOpen(true)}
-                  className="w-full bg-gradient-to-r from-artistic-pearl/20 to-artistic-silver/20 border border-artistic-silver/30 text-artistic-pearl hover:from-artistic-pearl/30 hover:to-artistic-silver/30 hover:text-white transition-all duration-300 backdrop-blur-sm"
+                  className="w-full bg-white/20 text-white font-['Montserrat'] font-medium hover:bg-white/30 transition-colors duration-300 uppercase text-sm tracking-wide rounded-md"
                   size="sm"
                 >
                   <Music className="w-4 h-4 mr-2" />
-                  New Music: "Be Like You"
+                  New Music
                 </Button>
               </div>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,14 @@ const slotMachineOptions = {
   press: ["PRESS", "MEDIA", "NEWS", "COVERAGE", "ARTICLES", "FEATURES"],
   contact: ["CONTACT", "REACH", "EMAIL", "BOOKING", "INQUIRIES", "CONNECT"],
   links: ["LINKS", "SOCIALS", "CONNECT", "FOLLOW", "CONTACT", "REACH"],
+  newMusic: [
+    "NEW MUSIC",
+    "NEW TRACK",
+    "PRESAVE",
+    "BE LIKE YOU",
+    "LATEST",
+    "FRESH",
+  ],
 };
 
 // Vertical marquee content

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { PageLayout } from "@/components/PageLayout";
 import { LoopingNavigationButtons } from "@/components/LoopingNavigationButtons";
+import { PresavePopup } from "@/components/PresavePopup";
 
 // Slot machine alternatives for each button
 const slotMachineOptions = {

--- a/src/utils/build-optimization.ts
+++ b/src/utils/build-optimization.ts
@@ -127,6 +127,7 @@ function setupResourceHints(): void {
     { href: "https://fonts.gstatic.com", rel: "dns-prefetch" },
     { href: "https://open.spotify.com", rel: "dns-prefetch" },
     { href: "https://music.apple.com", rel: "dns-prefetch" },
+    { href: "https://distrokid.com", rel: "dns-prefetch" },
   ];
 
   resourceHints.forEach(({ href, rel }) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -139,26 +139,24 @@ export default {
           espresso: "#734B34",
         },
 
-        // Minimal gold usage - only for rare accents
+        // Elegant luxury colors - pure silver and white palette
         luxury: {
           silver: "#C0C0C0",
           platinum: "#E5E4E2",
-          champagne: "#F7E7CE",
           pearl: "#EAE0C8",
-          cream: "#FFFDD0",
-          // Gold only for very rare occasions
-          gold: "#D4AF37", // More muted than pure gold
+          cream: "#F5F5F5",
+          white: "#FFFFFF",
+          light: "#D3D3D3", // Light silver
         },
 
-        // Elegant accent colors - mostly silvers and whites
+        // Elegant accent colors - silvers and whites only
         accent: {
           silver: "#C0C0C0",
           platinum: "#E5E4E2",
           pearl: "#EAE0C8",
-          cream: "#FFFDD0",
-          champagne: "#F7E7CE",
-          // Minimal gold usage
-          subtle: "#E8D5B7", // Very muted gold-ish
+          cream: "#F5F5F5",
+          white: "#FFFFFF",
+          subtle: "#D3D3D3", // Light silver
         },
       },
       fontFamily: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,7 +62,7 @@ export default {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
-        // Rolls-Royce inspired minimal palette - very little gold
+        // Rolls-Royce inspired minimal palette - elegant silver accents
         "primary-dark": "rgb(21, 21, 21)",
         "secondary-dark": "rgb(34, 34, 34)",
         "accent-gray": "rgb(59, 59, 59)",


### PR DESCRIPTION
This pull request adds a new PresavePopup component and updates the color scheme from gold to silver accents.

**New Component:**
- Added PresavePopup.tsx with auto-show functionality and localStorage persistence
- Includes configurable delay, manual trigger support, and responsive design
- Features track cover image, presave button linking to DistroKid, and close option

**Color Scheme Updates:**
- Replaced gold (#ffd700) with silver (#c0c0c0) throughout CSS variables
- Updated primary, accent, ring, and sidebar colors to use silver palette
- Changed class names from gold-* to silver-* (e.g., gold-shimmer → silver-shimmer)
- Updated gradient backgrounds and text effects to use silver tones

**Integration:**
- Added presave button to Index page with Music icon
- Popup auto-shows after 5 seconds with localStorage tracking
- Added DNS prefetch for distrokid.com domain
- Updated Tailwind config to remove gold colors and add silver variants

**Styling:**
- Maintained luxury aesthetic with silver, platinum, and white color palette
- Updated all glow effects, gradients, and text styling to use new colors
- Preserved existing component functionality while updating visual theme

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b1cd07c96c8b490f81207fa1d6d8fec8/aura-landing)

👀 [Preview Link](https://b1cd07c96c8b490f81207fa1d6d8fec8-aura-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1cd07c96c8b490f81207fa1d6d8fec8</projectId>-->
<!--<branchName>aura-landing</branchName>-->