### PR TITLE
Replace localStorage with sessionStorage for presave popup

### DIFF
--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -29,9 +29,9 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   const [open, setOpen] = useState(false);
   const [hasShown, setHasShown] = useState(false);
 
-  // Check localStorage on mount to prevent repeated auto-shows
+  // Check localStorage on mount to prevent repeated auto-shows in the same session
   useEffect(() => {
-    const hasSeenPopup = localStorage.getItem("presave-popup-shown");
+    const hasSeenPopup = sessionStorage.getItem("presave-popup-shown");
     if (hasSeenPopup) {
       setHasShown(true);
     }

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -42,8 +42,8 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
     onOpenChange?.(newOpen);
     if (newOpen) {
       setHasShown(true);
-      // Remember that user has seen the popup
-      localStorage.setItem("presave-popup-shown", "true");
+      // Remember that user has seen the popup for this session
+      sessionStorage.setItem("presave-popup-shown", "true");
     }
   };
 

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -53,7 +53,7 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
         if (!hasShown) {
           setOpen(true);
           setHasShown(true);
-          localStorage.setItem("presave-popup-shown", "true");
+          sessionStorage.setItem("presave-popup-shown", "true");
         }
       }, delay);
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -113,7 +113,7 @@ const Index = () => {
       {/* Presave Popup - Auto-shows after 5 seconds and manual trigger */}
       <PresavePopup
         autoShow={true}
-        delay={5000}
+        delay={1500}
         isOpen={presavePopupOpen}
         onOpenChange={setPresavePopupOpen}
       />


### PR DESCRIPTION
Changes presave popup tracking from localStorage to sessionStorage to reset popup visibility per browser session instead of persisting across sessions.

Updates all three instances of localStorage.getItem/setItem calls to use sessionStorage instead.

Also reduces the auto-show delay from 5000ms to 1500ms in the Index component.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b1cd07c96c8b490f81207fa1d6d8fec8/quantum-sanctuary)

👀 [Preview Link](https://b1cd07c96c8b490f81207fa1d6d8fec8-quantum-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1cd07c96c8b490f81207fa1d6d8fec8</projectId>-->
<!--<branchName>quantum-sanctuary</branchName>-->