### PR TITLE
Refactor PresavePopup state management and prop handling

### DIFF
--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -26,40 +26,41 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   autoShow = false,
   delay = 3000,
 }) => {
-  const [open, setOpen] = useState(false);
-  const [hasShown, setHasShown] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [hasAutoShown, setHasAutoShown] = useState(false);
 
-  // Check localStorage on mount to prevent repeated auto-shows in the same session
+  // Check sessionStorage on mount to prevent repeated auto-shows in the same session
   useEffect(() => {
     const hasSeenPopup = sessionStorage.getItem("presave-popup-shown");
     if (hasSeenPopup) {
-      setHasShown(true);
+      setHasAutoShown(true);
     }
   }, []);
 
   const handleOpenChange = (newOpen: boolean) => {
-    setOpen(newOpen);
+    setInternalOpen(newOpen);
     onOpenChange?.(newOpen);
     if (newOpen) {
-      setHasShown(true);
+      setHasAutoShown(true);
       // Remember that user has seen the popup for this session
       sessionStorage.setItem("presave-popup-shown", "true");
     }
   };
 
   useEffect(() => {
-    if (autoShow && !hasShown) {
+    if (autoShow && !hasAutoShown) {
       const timer = setTimeout(() => {
-        if (!hasShown) {
-          setOpen(true);
-          setHasShown(true);
+        if (!hasAutoShown) {
+          setInternalOpen(true);
+          setHasAutoShown(true);
           sessionStorage.setItem("presave-popup-shown", "true");
+          onOpenChange?.(true);
         }
       }, delay);
 
       return () => clearTimeout(timer);
     }
-  }, [autoShow, delay, hasShown]);
+  }, [autoShow, delay, hasAutoShown, onOpenChange]);
 
   const presaveUrl = "https://distrokid.com/hyperfollow/hiddnhills/be-like-you";
 

--- a/src/components/PresavePopup.tsx
+++ b/src/components/PresavePopup.tsx
@@ -114,12 +114,12 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
     </DialogContent>
   );
 
+  // Determine which open state to use - external prop takes precedence over internal state
+  const isDialogOpen = isOpen !== undefined ? isOpen : internalOpen;
+
   if (trigger) {
     return (
-      <Dialog
-        open={isOpen ?? open}
-        onOpenChange={onOpenChange ?? handleOpenChange}
-      >
+      <Dialog open={isDialogOpen} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>{trigger}</DialogTrigger>
         <PopupContent />
       </Dialog>
@@ -127,10 +127,7 @@ export const PresavePopup: React.FC<PresavePopupProps> = ({
   }
 
   return (
-    <Dialog
-      open={isOpen ?? open}
-      onOpenChange={onOpenChange ?? handleOpenChange}
-    >
+    <Dialog open={isDialogOpen} onOpenChange={handleOpenChange}>
       <PopupContent />
     </Dialog>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -110,11 +110,11 @@ const Index = () => {
         </div>
       </div>
 
-      {/* Presave Popup - Auto-shows after 5 seconds and manual trigger */}
+      {/* Presave Popup - Auto-shows after 1.5 seconds and manual trigger */}
       <PresavePopup
         autoShow={true}
         delay={1500}
-        isOpen={presavePopupOpen}
+        isOpen={presavePopupOpen || undefined}
         onOpenChange={setPresavePopupOpen}
       />
     </PageLayout>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -110,10 +110,10 @@ const Index = () => {
         </div>
       </div>
 
-      {/* Presave Popup - Auto-shows after 1.5 seconds and manual trigger */}
+      {/* Presave Popup - Auto-shows after 3 seconds and manual trigger */}
       <PresavePopup
         autoShow={true}
-        delay={1500}
+        delay={3000}
         isOpen={presavePopupOpen ? presavePopupOpen : undefined}
         onOpenChange={(open) => {
           setPresavePopupOpen(open);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -114,8 +114,10 @@ const Index = () => {
       <PresavePopup
         autoShow={true}
         delay={1500}
-        isOpen={presavePopupOpen || undefined}
-        onOpenChange={setPresavePopupOpen}
+        isOpen={presavePopupOpen ? presavePopupOpen : undefined}
+        onOpenChange={(open) => {
+          setPresavePopupOpen(open);
+        }}
       />
     </PageLayout>
   );


### PR DESCRIPTION
Refactors the PresavePopup component to improve state management and prop handling:

- Renames internal state variables for clarity: `open` → `internalOpen`, `hasShown` → `hasAutoShown`
- Adds logic to determine which open state to use, with external `isOpen` prop taking precedence over internal state
- Simplifies Dialog component usage by consolidating open state logic
- Ensures `onOpenChange` callback is properly called during auto-show functionality
- Updates delay from 1500ms to 3000ms in Index.tsx
- Modifies `isOpen` prop passing to use conditional logic instead of direct boolean value

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b1cd07c96c8b490f81207fa1d6d8fec8/glow-space)

👀 [Preview Link](https://b1cd07c96c8b490f81207fa1d6d8fec8-glow-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1cd07c96c8b490f81207fa1d6d8fec8</projectId>-->
<!--<branchName>glow-space</branchName>-->