### PR TITLE
Improve mobile touch targets and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # HIDDNHILLS - Art over Ego
+
 > Underground Hip-Hop Visionary • Las Vegas
 
 ## Features
@@ -44,4 +45,4 @@
 
 ---
 
-_Underground Visionary • Art over Ego
+\_Underground Visionary • Art over Ego

--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,7 +3322,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001660",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "dev": true,
       "funding": [
         {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -142,7 +142,7 @@ const DesktopNavButton = memo<{ link: NavLink }>(({ link }) => {
         size="sm"
         className={cn(
           "text-white/80 hover:text-white hover:bg-white/10 transition-all duration-300",
-          "px-1.5 py-1 text-xs font-medium uppercase font-['Montserrat']",
+          "px-1.5 py-1 text-xs sm:text-xs font-medium uppercase font-['Montserrat'] min-h-[44px]",
         )}
       >
         <a

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -164,7 +164,7 @@ const DesktopNavButton = memo<{ link: NavLink }>(({ link }) => {
       variant="ghost"
       size="sm"
       className={cn(
-        "transition-all duration-300 px-1.5 py-1 text-xs font-medium uppercase font-['Montserrat']",
+        "transition-all duration-300 px-1.5 py-1 text-xs sm:text-xs font-medium uppercase font-['Montserrat'] min-h-[44px]",
         isActive
           ? "text-white bg-white/20 hover:bg-white/30"
           : "text-white/80 hover:text-white hover:bg-white/10",

--- a/src/components/SlotMachineButton.tsx
+++ b/src/components/SlotMachineButton.tsx
@@ -122,7 +122,7 @@ export const SlotMachineButton = memo<SlotMachineButtonProps>(
       () =>
         cn(
           "text-white/80 hover:text-white bg-transparent border-none outline-none font-light",
-          "px-2 py-1 text-xs tracking-[1px] uppercase transition-all duration-300",
+          "px-3 py-2 text-xs tracking-[1px] uppercase transition-all duration-300 min-h-[44px] touch-manipulation",
           "focus:outline-none focus:ring-0 focus:border-none",
           showUnderline && [
             "underline decoration-white/40 hover:decoration-white underline-offset-4",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation",
   {
     variants: {
       variant: {


### PR DESCRIPTION
This pull request includes several improvements for mobile usability and dependency updates:

**Mobile Touch Target Improvements:**
- Added `min-h-[44px]` to navigation buttons for better touch accessibility
- Added `touch-manipulation` CSS property to buttons and slot machine component
- Increased padding on SlotMachineButton from `px-2 py-1` to `px-3 py-2`

**Dependency Updates:**
- Updated caniuse-lite from version 1.0.30001660 to 1.0.30001727

**Minor Formatting:**
- Added blank line after main heading in README.md
- Escaped underscore in README.md footer text

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b1cd07c96c8b490f81207fa1d6d8fec8/flare-nest)

👀 [Preview Link](https://b1cd07c96c8b490f81207fa1d6d8fec8-flare-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1cd07c96c8b490f81207fa1d6d8fec8</projectId>-->
<!--<branchName>flare-nest</branchName>-->